### PR TITLE
feat: wordExamples -> wordExample 변수명 변경

### DIFF
--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -14,7 +14,7 @@ export default function Detail() {
       wordDescription,
       wordSpeak,
       wrongSpeak,
-      wordExamples,
+      wordExample,
       wordDiacritic,
     },
   } = useWordDetail(Number(wordId));
@@ -57,15 +57,21 @@ export default function Detail() {
           <h3 className="font-semibold text-main-black pb-1.5">의미</h3>
           <p className="text-main-gray">{wordDescription}</p>
         </div>
-        {wordExamples && (
+        {wordExample && (
           <div className="p-[18px] rounded-[16px] border border-[#F2F4F9] shadow-base bg-white">
             <h3 className="font-semibold text-main-black pb-1.5">예문</h3>
-            {wordExamples.split('$').map((example, idx) => (
-              <div className="text-main-gray flex items-center gap-2" key={idx}>
-                <div className="w-1 h-1 rounded-full bg-main-charcoal self-start mt-2.5 flex-shrink-0" />
-                <p className="text-main-gray">{example}</p>
-              </div>
-            ))}
+            {wordExample
+              .split('$')
+              .filter((example) => example.trim())
+              .map((example, idx) => (
+                <div
+                  className="text-main-gray flex items-center gap-2"
+                  key={idx}
+                >
+                  <div className="w-1 h-1 rounded-full bg-main-charcoal self-start mt-2.5 flex-shrink-0" />
+                  <p className="text-main-gray">{example}</p>
+                </div>
+              ))}
           </div>
         )}
       </main>

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -37,5 +37,5 @@ export type WordDetail = {
   wrongSpeak: string; // 틀린 발음 리스트 (컴마까지 합쳐서 스트링으로)
   wordDiacritic: string; // 한국 -> 영어 발음 기호
   wordDescription: string; // 단어 설명
-  wordExamples: string | null; // 예문 리스트 ($로 구분)
+  wordExample: string | null; // 예문 리스트 ($로 구분)
 };


### PR DESCRIPTION
## 📌 기능 설명
<!-- 기능을 대략적으로 설명해주세요 -->
<!-- ex)
- [x] 디테일 페이지 마크업 
- [x] 헤더 컴포넌트 구현 
-->
- 백엔드 변수명이 wordExamples 가 아닌 wordExample로 되어 있어서 변경했습니다
## 📌 구현 내용
<!-- 실제 구현 내용을 디테일하게 작성해 주세요 -->

<!-- ex)
- 피그마에 디자인된 사항으로 마크업을 구현했습니다.
- 헤더 컴포넌트에 필요한 이벤트를 hook으로 구현했습니다. 
-->

## 📌 구현 결과
<!-- 구현 결과를 확인할 수 있는 방법 혹은 이미지를 첨부해주세요. -->

## 📌 논의하고 싶은 점
<!-- 논의하고 싶은 점이 있다면 적어주세요 -->
<!-- ex)
react-query 를 사용할 때 별도의 hook으로 만들어서 사용하시나요?
저는 별도로 사용하지 않는데 어떻게 하는게 좋을까요? 
-->